### PR TITLE
Fix Structures Bounding Boxes

### DIFF
--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/CyclopsCaveStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/CyclopsCaveStructure.java
@@ -81,6 +81,9 @@ public class CyclopsCaveStructure extends Structure implements DangerousGenerati
 
         @Override
         public void generate(StructureWorldAccess world, StructureAccessor structureAccessor, ChunkGenerator chunkGenerator, Random random, BlockBox chunkBox, ChunkPos chunkPos, BlockPos pivot) {
+            if (!chunkBox.contains(pivot))
+                return;
+
             int size = 16;
             generateShell(world, pivot, random, size);
 
@@ -230,10 +233,11 @@ public class CyclopsCaveStructure extends Structure implements DangerousGenerati
             return Blocks.OAK_FENCE.getDefaultState().with(FenceBlock.EAST, east).with(FenceBlock.WEST, west).with(FenceBlock.NORTH, north).with(FenceBlock.SOUTH, south);
         }
 
-        private static void generateShell(StructureWorldAccess world, BlockPos origin, Random random, int size) {
+        private void generateShell(StructureWorldAccess world, BlockPos origin, Random random, int size) {
             int x = size + random.nextInt(2);
             int y = 12 + random.nextInt(2);
             int z = size + random.nextInt(2);
+            super.boundingBox = new BlockBox(origin.getX() - x + 2, origin.getY(), origin.getZ() - z + 2, origin.getX() + x - 2, origin.getY() + y, origin.getZ() + z - 2);
             float radius = (x + y + z) * 0.333F + 0.5F;
 
             for (BlockPos position : BlockPos.stream(origin.add(-x, -y, -z), origin.add(x, y, z)).map(BlockPos::toImmutable).collect(Collectors.toSet())) {

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/DragonCaveStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/DragonCaveStructure.java
@@ -101,6 +101,13 @@ public abstract class DragonCaveStructure extends Structure implements Dangerous
 
         @Override
         public void generate(StructureWorldAccess world, StructureAccessor structureAccessor, ChunkGenerator chunkGenerator, Random random, BlockBox chunkBox, ChunkPos chunkPos, BlockPos pivot) {
+            if (super.boundingBox.getBlockCountX() > 1)
+                return;
+            BlockPos center = new BlockPos(super.boundingBox.getMinX(), super.boundingBox.getMinY(), super.boundingBox.getMinZ()).subtract(this.offset);
+            BlockPos bb_pos = center.add(new BlockPos((this.offset.getX() * 24) / 32, 0, (this.offset.getZ() * 24) / 32));
+            super.boundingBox = new BlockBox(bb_pos.getX() - 12, super.boundingBox.getMinY(), bb_pos.getZ() - 12,
+                                             bb_pos.getX() + 11, super.boundingBox.getMaxY(), bb_pos.getZ() + 11);
+
             random = new CheckedRandom(this.seed);
             // Center the position at the "middle" of the chunk
             BlockPos position = new BlockPos((chunkPos.x << 4) + 8, this.y, (chunkPos.z << 4) + 8).subtract(this.offset);

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/DragonRoostStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/DragonRoostStructure.java
@@ -76,6 +76,9 @@ public abstract class DragonRoostStructure extends Structure implements Dangerou
 
         @Override
         public void generate(StructureWorldAccess world, StructureAccessor structureAccessor, ChunkGenerator chunkGenerator, Random random, BlockBox chunkBox, ChunkPos chunkPos, BlockPos pivot) {
+            if (!chunkBox.contains(pivot))
+                return;
+
             int radius = 12 + random.nextInt(8);
             this.spawnDragon(world, pivot, random, radius, this.isMale);
             this.generateSurface(world, pivot, random, radius);
@@ -230,6 +233,9 @@ public abstract class DragonRoostStructure extends Structure implements Dangerou
         private void generateShell(StructureWorldAccess world, BlockPos origin, Random random, int radius) {
             int height = (radius / 5);
             double circularArea = this.getCircularArea(radius, height);
+
+            int real_radius = (int) Math.sqrt(circularArea);
+            super.boundingBox = new BlockBox(origin.getX() - real_radius, origin.getY(), origin.getZ() - real_radius, origin.getX() + real_radius, origin.getY() + 3, origin.getZ() + real_radius);
 
             BlockPos.stream(origin.add(-radius, -height, -radius), origin.add(radius, 1, radius)).map(BlockPos::toImmutable).forEach(position -> {
                 if (position.getSquaredDistance(origin) < circularArea)

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/HydraCaveStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/HydraCaveStructure.java
@@ -78,6 +78,9 @@ public class HydraCaveStructure extends Structure implements DangerousGeneration
 
         @Override
         public void generate(StructureWorldAccess world, StructureAccessor structureAccessor, ChunkGenerator chunkGenerator, Random random, BlockBox chunkBox, ChunkPos chunkPos, BlockPos pivot) {
+            if (!chunkBox.contains(pivot))
+                return;
+
             int i1 = 8;
             int i2 = i1 - 2;
             {
@@ -86,6 +89,7 @@ public class HydraCaveStructure extends Structure implements DangerousGeneration
                 int k = 5 + ySize;
                 int l = i1 + random.nextInt(2);
                 float f = (j + k + l) * 0.333F + 0.5F;
+                super.boundingBox = new BlockBox(pivot.getX() - j + 2, pivot.getY(), pivot.getZ() - l + 2, pivot.getX() + j - 2, pivot.getY() + k, pivot.getZ() + l - 2);
 
                 for (BlockPos blockpos : BlockPos.stream(pivot.add(-j, -k, -l), pivot.add(j, k, l)).map(BlockPos::toImmutable).collect(Collectors.toSet())) {
                     boolean doorwayX = blockpos.getX() >= pivot.getX() - 2 + random.nextInt(2) && blockpos.getX() <= pivot.getX() + 2 + random.nextInt(2);

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/PixieVillageStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/PixieVillageStructure.java
@@ -28,6 +28,8 @@ import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.gen.structure.Structure;
 import net.minecraft.world.gen.structure.StructureType;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 public class PixieVillageStructure extends Structure {
@@ -69,15 +71,21 @@ public class PixieVillageStructure extends Structure {
 
         @Override
         public void generate(StructureWorldAccess world, StructureAccessor structureAccessor, ChunkGenerator chunkGenerator, Random random, BlockBox chunkBox, ChunkPos chunkPos, BlockPos pivot) {
+            if (!chunkBox.contains(pivot))
+                return;
+
             int maxRoads = IafCommonConfig.INSTANCE.pixie.size.getValue() + random.nextInt(5);
             BlockPos buildPosition = pivot;
             int placedRoads = 0;
+            List<BlockPos> posesInBB = new ArrayList<BlockPos>();
             while (placedRoads < maxRoads) {
                 int roadLength = 10 + random.nextInt(15);
                 Direction buildingDirection = Direction.fromHorizontal(random.nextInt(3));
                 for (int i = 0; i < roadLength; i++) {
                     BlockPos buildPosition2 = buildPosition.offset(buildingDirection, i);
                     buildPosition2 = world.getTopPosition(Heightmap.Type.WORLD_SURFACE_WG, buildPosition2).down();
+                    if (chunkBox.expand(16, 0, 16).contains(buildPosition2))
+                        posesInBB.add(buildPosition2);
                     if (world.getBlockState(buildPosition2).getFluidState().isEmpty()) {
                         world.setBlockState(buildPosition2, Blocks.DIRT_PATH.getDefaultState(), 2);
                     } else {
@@ -118,6 +126,7 @@ public class PixieVillageStructure extends Structure {
                 buildPosition = buildPosition.offset(buildingDirection, random.nextInt(roadLength));
                 placedRoads++;
             }
+            super.boundingBox = BlockBox.encompassPositions(posesInBB).orElseGet(super::getBoundingBox).expand(0, 2, 0);
         }
     }
 }

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/SirenIslandStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/SirenIslandStructure.java
@@ -68,10 +68,17 @@ public class SirenIslandStructure extends Structure implements DangerousGenerati
 
         @Override
         public void generate(StructureWorldAccess world, StructureAccessor structureAccessor, ChunkGenerator chunkGenerator, Random random, BlockBox chunkBox, ChunkPos chunkPos, BlockPos pivot) {
+            if (!chunkBox.contains(pivot))
+                return;
+
             int up = random.nextInt(4) + 1;
             BlockPos center = pivot.up(up);
             int layer = 0;
             int sirens = 1 + random.nextInt(3);
+
+            int radius = this.getRadius(up, up);
+            super.boundingBox = new BlockBox(center.getX() - radius, center.getY() - up, center.getZ() - radius,
+                                             center.getX() + radius, center.getY() + 1, center.getZ() + radius);
 
             while (!world.getBlockState(center).isOpaque() && center.getY() >= world.getBottomY()) {
                 layer++;


### PR DESCRIPTION
Structure bounding boxes are 1 by 1 by 1 block. 

This is an issue as it prevent setting a quest to search for the structure in FTB Quest.
For example this issue on ATM10 where the devs did not test their quests: https://github.com/AllTheMods/ATM-10/issues/3415 and this video show the bounding boxes: https://www.youtube.com/watch?v=0GkZxofgmzk.

This merge request fix the bounding boxes without breaking the structure generation more than it currently is.

The bounding box is set up in the `StructurePiece` constructor, but it can be updated during the generation, so we can just set the boundingbox to the right size when we know the correct size.

The `terrain_adaptation` is based on the boundingbox at the generation of the `StructurePiece`, when updating the boundingbox after the fact the `terrain_adaptation` is not changed. Doing this prevents the dragon roost generating inside a hole.

The generation function is call for each chunk that the boundingbox of the `StructurePiece` encompass, as the current structure generation is coded to generate from one call on the center chunk we have to dismiss all the others calls. (These are the guard at the start of all `generate` function. (same concept for the DragonCave but with different logic))

I would suggest reworking the generation to only set block on the current chunk of the generate function as there is no guaranty that adjacent chunk are generated, and that block state changes will be successful.
While adjacent chunk of the current one are generally "relatively" safe, this can cause issues if the structure generate too far in un-generated chunks, an example of that if the pixie village structure that near always try to generate very far from its origin (like 70 blocks) and does not generate any more past the 3x3 origin chunks. This is the reason of the `if (chunkBox.expand(16, 0, 16).contains(buildPosition2))` guard, to avoid generating a bounding box 70 blocks away from the actual village.

This is what the boundingbox looks like with this patch:

<img width="1920" height="1080" alt="dragon_cave" src="https://github.com/user-attachments/assets/bc420d81-08ef-4fc2-aeea-fa740973bdcb" />
<img width="1920" height="1080" alt="dragon_roost" src="https://github.com/user-attachments/assets/4371d77a-759b-42c9-a71b-905fdc56aa8d" />
<img width="1920" height="1080" alt="hydra_cave" src="https://github.com/user-attachments/assets/0497d70a-7ae7-4468-a3d7-56e684e56a56" />
<img width="1920" height="1080" alt="pixie_village" src="https://github.com/user-attachments/assets/c73f9403-7fd7-45e7-8128-a1aa56fde6f5" />
<img width="1920" height="1080" alt="siren_island" src="https://github.com/user-attachments/assets/ea1a3077-1d95-45dc-a9e9-318fa3a3480b" />
<img width="1920" height="1080" alt="cyclops_cave" src="https://github.com/user-attachments/assets/f3044833-e18c-4d94-9ec2-93b4b3310242" />

I use the [bocchud](https://www.curseforge.com/minecraft/mc-mods/bocchud) mod to show the bounding boxes.
