### PR TITLE
fix: dragon wing animation

### DIFF
--- a/common/src/main/java/com/iafenvoy/iceandfire/entity/DragonBaseEntity.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/entity/DragonBaseEntity.java
@@ -1610,6 +1610,17 @@ public abstract class DragonBaseEntity extends TameableEntity implements Extende
     @Override
     public void tick() {
         super.tick();
+        // Capture previous animation progress BEFORE they are updated this tick,
+        // so the renderer can properly interpolate between frames.
+        this.prevModelDeadProgress = this.modelDeadProgress;
+        this.prevDiveProgress = this.diveProgress;
+        this.prevAnimationProgresses[0] = this.sitProgress;
+        this.prevAnimationProgresses[1] = this.sleepProgress;
+        this.prevAnimationProgresses[2] = this.hoverProgress;
+        this.prevAnimationProgresses[3] = this.flyProgress;
+        this.prevAnimationProgresses[4] = this.fireBreathProgress;
+        this.prevAnimationProgresses[5] = this.ridingProgress;
+        this.prevAnimationProgresses[6] = this.tackleProgress;
         //TODO: Better detect logic
         if (!IntegrationExecutor.getWhenLoad("ponder", () -> () -> this.getWorld() instanceof SchematicLevel, () -> false)) {
             this.calculateDimensions();
@@ -1666,15 +1677,6 @@ public abstract class DragonBaseEntity extends TameableEntity implements Extende
     @Override
     public void tickMovement() {
         super.tickMovement();
-        this.prevModelDeadProgress = this.modelDeadProgress;
-        this.prevDiveProgress = this.diveProgress;
-        this.prevAnimationProgresses[0] = this.sitProgress;
-        this.prevAnimationProgresses[1] = this.sleepProgress;
-        this.prevAnimationProgresses[2] = this.hoverProgress;
-        this.prevAnimationProgresses[3] = this.flyProgress;
-        this.prevAnimationProgresses[4] = this.fireBreathProgress;
-        this.prevAnimationProgresses[5] = this.ridingProgress;
-        this.prevAnimationProgresses[6] = this.tackleProgress;
         if (this.getWorld().getDifficulty() == Difficulty.PEACEFUL && this.getTarget() instanceof PlayerEntity) {
             this.setTarget(null);
         }

--- a/common/src/main/java/com/iafenvoy/iceandfire/render/model/animator/DragonTabulaModelAnimator.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/render/model/animator/DragonTabulaModelAnimator.java
@@ -67,11 +67,11 @@ public abstract class DragonTabulaModelAnimator<T extends DragonBaseEntity> exte
 
         TabulaModel<T> currentPosition = swimming ? this.swimPoses[currentIndex] : walking ? this.walkPoses[currentIndex] : this.flyPoses[currentIndex];
         TabulaModel<T> prevPosition = swimming ? this.swimPoses[prevIndex] : walking ? this.walkPoses[prevIndex] : this.flyPoses[prevIndex];
-        float delta = ((walking ? entity.walkCycle : entity.flightCycle) / 10.0F) % 1.0F;
-        if (swimming) delta = (entity.swimCycle / 10.0F) % 1.0F;
         float partialTick = MinecraftClient.getInstance().getRenderTickCounter().getTickDelta(false);
-        float deltaTicks = delta + (partialTick / 10.0F);
-        if (delta == 0) deltaTicks = 0;
+        float cyclePos = swimming ? entity.swimCycle : walking ? entity.walkCycle : entity.flightCycle;
+        float tickAdvance = (walking || swimming) ? 1.0F : 2.0F;
+        float smoothCycle = cyclePos + partialTick * tickAdvance;
+        float deltaTicks = (smoothCycle / 10.0F) % 1.0F;
 
         float speed_walk = 0.2F;
         float speed_idle = entity.isSleeping() ? 0.025F : 0.05F;


### PR DESCRIPTION
## Problem
Dragon wings during flight exhibit a "choppy" frame-by-frame stutter — the
wing flap motion visibly snaps between discrete positions every game tick
rather than rendering smooth continuous motion. This is especially noticeable
at higher framerates (60+ FPS), where the wings appear to jump 3-4 rendered
frames, then hold, then jump again.
## Root Cause
Two independent issues contributed to the jitter:
### 1. Insufficient sub-tick interpolation (primary cause)
In `DragonTabulaModelAnimator.setRotationAngles()`, the keyframe blend factor
`deltaTicks` was computed as:
```java
deltaTicks = delta + (partialTick / 10.0F);
```
The `flightCycle` field advances by **2** per game tick, but `partialTick / 10.0`
only accounts for a **1-unit-per-tick** interpolation offset (max contribution
of 0.1 to the blend factor). This left a gap of ~0.1 units between the last
rendered frame of one tick and the first rendered frame of the next, producing
a visible position jump.
Concrete example (flightCycle values and rendered blend factors):
- Tick N: blend factor goes 0.40 → 0.45 → 0.50 (correct: 0.40 → 0.46 → 0.53)
- Tick N+1: blend factor jumps to 0.60 (should smoothly arrive at 0.60)
The jump from 0.50 to 0.60 is the visible "snap" perceived as jitter.
### 2. Misplaced `prevAnimationProgresses` snapshot (secondary cause)
In `DragonBaseEntity`, the `prevAnimationProgresses` array (used for broad pose
transitions like ground→flying→hovering) was snapshotted in `tickMovement()`,
which runs **after** `tick()` has already updated the progress fields via
`updateDragonCommon()`. Since `prev` equaled `current` at render time,
`MathHelper.lerp(partialTick, prev, current)` always returned `current` — zero
interpolation across pose transitions.
## Changes
### File 1: `DragonTabulaModelAnimator.java` (lines 70-74)
Replaced the per-state `delta` computation and under-scaling `partialTick / 10.0`
with a unified smooth-cycle formula that correctly accounts for each animation
state's tick advance rate:
```java
// Before
float delta = ((walking ? entity.walkCycle : entity.flightCycle) / 10.0F) % 1.0F;
if (swimming) delta = (entity.swimCycle / 10.0F) % 1.0F;
float deltaTicks = delta + (partialTick / 10.0F);
if (delta == 0) deltaTicks = 0;
// After
float partialTick = MinecraftClient.getInstance().getRenderTickCounter().getTickDelta(false);
float cyclePos = swimming ? entity.swimCycle : walking ? entity.walkCycle : entity.flightCycle;
float tickAdvance = (walking || swimming) ? 1.0F : 2.0F;
float smoothCycle = cyclePos + partialTick * tickAdvance;
float deltaTicks = (smoothCycle / 10.0F) % 1.0F;
```
The `tickAdvance` factor (2 for flight, 1 for walk/swim) ensures `partialTick`
correctly bridges the entire inter-tick gap, producing seamless keyframe
blending at any framerate.
### File 2: `DragonBaseEntity.java`
Moved the `prevAnimationProgresses` (and `prevModelDeadProgress`,
`prevDiveProgress`) capture from `tickMovement()` to the start of `tick()`,
**before** `updateDragonCommon()` modifies the fields. The renderer now receives
the true previous-tick values, enabling proper `MathHelper.lerp` interpolation
across all pose transitions (ground↔flying, hovering↔diving, etc.).
Both walk-cycle and swim-cycle keyframe blending also benefit from the improved
sub-tick interpolation, though the user-visible improvement is most dramatic
for dragon wing flight animation.